### PR TITLE
Huge performance boost + less verbose log output

### DIFF
--- a/packages/graphql-codegen-core/src/operations/transform-document.ts
+++ b/packages/graphql-codegen-core/src/operations/transform-document.ts
@@ -73,8 +73,7 @@ export function transformDocument(schema: GraphQLSchema, documentNode: DocumentN
       const overrideName = fixAnonymousDocument(definitionNode as FragmentDefinitionNode);
       result.fragments.push(transformFragment(schema, definitionNode as FragmentDefinitionNode, overrideName));
     } else {
-      logger.warn(`It seems like you provided an invalid GraphQL document: `);
-      logger.warn(definitionNode);
+      logger.warn(`It seems like you provided an invalid GraphQL document of kind "${definitionNode.kind}".`);
     }
   });
 


### PR DESCRIPTION
Before fix: +3min
After fix: <1sec

Some profiling with 0x showed that winston uses cyclejs to deep copy the object before serialization. This is extremely slow and the not worth more information in a warning message.

Some local and totally non-scientific benchmarks:

BEFORE FIX:
```
$ date; NODE_ENV=production ./node_modules/.bin/gql-gen --schema $CODEGEN_DIR/tmp/schema.json --template graphql-codegen-typescript-template --out $BASE_DIR/server/.codegen/typings/ $CODEGEN_DIR/tmp/schema.graphql > $CODEGEN_DIR/log/servergen.log; date
Tue 17 Jul 2018 11:56:02 CEST
Tue 17 Jul 2018 11:59:57 CEST

===> ~4min

$ ls -lah $CODEGEN_DIR/log/servergen.log
-rw-r--r--  1 prevostc  staff   189M 17 Jul 11:59 ./.codegen/log/servergen.log
```

AFTER FIX:
```
date; NODE_ENV=production ./node_modules/.bin/gql-gen --schema $CODEGEN_DIR/tmp/schema.json --template graphql-codegen-typescript-template --out $BASE_DIR/server/.codegen/typings/ $CODEGEN_DIR/tmp/schema.graphql > $CODEGEN_DIR/log/servergen.log; date
Tue 17 Jul 2018 11:55:46 CEST
Tue 17 Jul 2018 11:55:47 CEST

===> <1sec

$ ls -lah $CODEGEN_DIR/log/servergen.log
-rw-r--r--  1 prevostc  staff   4.5K 17 Jul 11:59 ./.codegen/log/servergen.log
```


Please note that the code generated by this package is correct and that I don't know why I get these warnings :)